### PR TITLE
Better custom component support

### DIFF
--- a/lib/live_toast.ex
+++ b/lib/live_toast.ex
@@ -141,23 +141,24 @@ defmodule LiveToast do
   Since this is a public function, you can also write a new function that calls it and extends it's return values.
   """
   def toast_class_fn(assigns) do
-    if assigns[:component] do
+    shared_classes =
       [
+        # start hidden if javascript is enabled
+        "[@media(scripting:enabled)]:opacity-0 [@media(scripting:enabled){[data-phx-main]_&}]:opacity-100",
         # used to hide the disconnected flashes
         if(assigns[:rest][:hidden] == true, do: "hidden", else: "flex")
       ]
+
+    if assigns[:component] do
+      shared_classes
     else
       [
         # base classes
         "bg-white group/toast z-100 pointer-events-auto relative w-full items-center justify-between origin-center overflow-hidden rounded-lg p-4 shadow-lg border col-start-1 col-end-1 row-start-1 row-end-2",
-        # start hidden if javascript is enabled
-        "[@media(scripting:enabled)]:opacity-0 [@media(scripting:enabled){[data-phx-main]_&}]:opacity-100",
-        # used to hide the disconnected flashes
-        if(assigns[:rest][:hidden] == true, do: "hidden", else: "flex"),
         # override styles per severity
         assigns[:kind] == :info && "text-black",
         assigns[:kind] == :error && "!text-red-700 !bg-red-100 border-red-200"
-      ]
+      ] ++ shared_classes
     end
   end
 

--- a/lib/live_toast.ex
+++ b/lib/live_toast.ex
@@ -141,17 +141,24 @@ defmodule LiveToast do
   Since this is a public function, you can also write a new function that calls it and extends it's return values.
   """
   def toast_class_fn(assigns) do
-    [
-      # base classes
-      "bg-white group/toast z-100 pointer-events-auto relative w-full items-center justify-between origin-center overflow-hidden rounded-lg p-4 shadow-lg border col-start-1 col-end-1 row-start-1 row-end-2",
-      # start hidden if javascript is enabled
-      "[@media(scripting:enabled)]:opacity-0 [@media(scripting:enabled){[data-phx-main]_&}]:opacity-100",
-      # used to hide the disconnected flashes
-      if(assigns[:rest][:hidden] == true, do: "hidden", else: "flex"),
-      # override styles per severity
-      assigns[:kind] == :info && "text-black",
-      assigns[:kind] == :error && "!text-red-700 !bg-red-100 border-red-200"
-    ]
+    if assigns[:component] do
+      [
+        # used to hide the disconnected flashes
+        if(assigns[:rest][:hidden] == true, do: "hidden", else: "flex")
+      ]
+    else
+      [
+        # base classes
+        "bg-white group/toast z-100 pointer-events-auto relative w-full items-center justify-between origin-center overflow-hidden rounded-lg p-4 shadow-lg border col-start-1 col-end-1 row-start-1 row-end-2",
+        # start hidden if javascript is enabled
+        "[@media(scripting:enabled)]:opacity-0 [@media(scripting:enabled){[data-phx-main]_&}]:opacity-100",
+        # used to hide the disconnected flashes
+        if(assigns[:rest][:hidden] == true, do: "hidden", else: "flex"),
+        # override styles per severity
+        assigns[:kind] == :info && "text-black",
+        assigns[:kind] == :error && "!text-red-700 !bg-red-100 border-red-200"
+      ]
+    end
   end
 
   @doc """
@@ -213,6 +220,8 @@ defmodule LiveToast do
     doc: "function to override the toast classes"
   )
 
+  attr(:component, :any, default: nil, doc: "the optional component to render the flash message")
+
   @doc """
   Renders a group of toasts and flashes.
 
@@ -229,6 +238,7 @@ defmodule LiveToast do
       group_class_fn={@group_class_fn}
       f={@flash}
       kinds={@kinds}
+      component={@component}
     />
     <Components.flash_group
       :if={!@connected}
@@ -238,6 +248,7 @@ defmodule LiveToast do
       group_class_fn={@group_class_fn}
       flash={@flash}
       kinds={@kinds}
+      component={@component}
     />
     """
   end

--- a/lib/live_toast/live_component.ex
+++ b/lib/live_toast/live_component.ex
@@ -57,7 +57,7 @@ defmodule LiveToast.LiveComponent do
           duration={duration}
           kind={k}
           toast_class_fn={@toast_class_fn}
-          component={component}
+          component={component || @component}
           icon={icon}
           action={action}
           corner={@corner}
@@ -74,7 +74,13 @@ defmodule LiveToast.LiveComponent do
         </Components.toast>
       </div>
 
-      <Components.flashes f={@f} corner={@corner} toast_class_fn={@toast_class_fn} kinds={@kinds} />
+      <Components.flashes
+        f={@f}
+        corner={@corner}
+        toast_class_fn={@toast_class_fn}
+        component={@component}
+        kinds={@kinds}
+      />
     </div>
     """
   end


### PR DESCRIPTION
This is a WIP, but mainly I was trying to have a completely custom component for all flashes/toasts.

I realized that the DX was weird because I had to pass the component each time. Worse than that, the X icon was still being rendered even with a custom component.

So I'm trying to improve this by:
- Allowing `component` to be passed straight to `LiveToast.toast_group` function
- Use that by default if the update received in the LiveComponent doesn't include a component
- Not rendering the close button when custom component is passed (breaking change)
- Passing `phx-*` attributes to be used for closing the toast down to the component, so one can place the close button/action wherever they want.
- Setting a more minimalist classes on the wrapping div when component is passed (breaking change).

This is still missing a lot of important details. I also was failing to run the tests because some Jason issue that I'll look into after.

But with this setup I was able to customize the toast completely with the following toast component:

```elixir
defmodule PursonalWeb.CoreComponents.Toast do
  use Phoenix.Component

  import Heroicons.LiveView
  import Turboprop.Variants

  @variant_config [
    slots: [
      base: [
        "group",
        "pointer-events-auto",
        "relative",
        "flex",
        "w-full",
        "items-center",
        "justify-between",
        "space-x-4",
        "overflow-hidden",
        "rounded-md",
        "p-6",
        "pr-8",
        "shadow-lg",
        "transition-all",
        "mt-4"
      ],
      cross: [
        "absolute",
        "right-2",
        "top-2",
        "rounded-md",
        "p-1",
        "opacity-0",
        "transition-opacity",
        "focus:opacity-100",
        "focus:outline-none",
        "focus:ring-2",
        "group-hover:opacity-100"
      ]
    ],
    variants: [
      variant: [
        default: [
          base: "bg-background text-foreground border",
          cross: "text-foreground/50 hover:text-foreground"
        ],
        destructive: [
          base: "bg-destructive text-destructive-foreground",
          cross: "text-destructive-foreground/50 hover:text-destructive-foreground"
        ]
      ]
    ]
  ]

  attr :id, :string, doc: "the optional id of flash container"
  attr :title, :string, default: nil
  attr :body, :string, default: ""
  attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
  attr :action, :any, doc: "Optinal action component"
  attr :close_args, :any, default: []

  def toast(assigns) do
    assigns =
      assigns
      |> assign(:base_variant_class, toast_variant(assigns, :base))
      |> assign(:cross_variant_class, toast_variant(assigns, :cross))

    ~H"""
    <div role="status" aria-live="off" aria-atomic="true" tabindex="0" class={@base_variant_class}>
      <div class="grid gap-1">
        <div :if={@title} class="text-sm font-semibold" data-part="title"><%= @title %></div>
        <div class="text-sm opacity-90"><%= @body %></div>
      </div>
      <button type="button" class={@cross_variant_class} {@close_args}>
        <.icon name="x-mark" type="solid" class="h-5 w-5" />
      </button>
    </div>
    """
  end

  defp toast_variant(assigns, slot) do
    variant(@variant_config, slot: slot, variant: variant_name(assigns))
  end

  defp variant_name(%{kind: :error}), do: :destructive
  defp variant_name(_), do: :default
end
```