### PR TITLE
Allow multiple instances of toast group

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ end
 Then just make sure you've passed it to the `live_group` component as seen above.
 
 
+### Using `live_render`
+
+When rendering a LiveView within another LiveView, the flash assigns (like all other assigns) are not shared.
+This means that the nested LiveView must use its own "flash group" (or equivalent, e.g. toast group) in its HTML.
+When doing this, it is prudent to set the `:show_client_and_server_flashes` attr to `false`.
+That way the nested LiveView will not show client/server error flashes, which will already be shown by the parent LiveView.
+
+
 ### JavaScript Options
 
 You can also change some options about the LiveView hook when it is initialized. Such as:

--- a/lib/live_toast.ex
+++ b/lib/live_toast.ex
@@ -213,6 +213,11 @@ defmodule LiveToast do
     doc: "function to override the toast classes"
   )
 
+  attr(:show_client_and_server_flashes, :boolean,
+    default: true,
+    doc: "optional boolean to include/exclude the client-error and server-error flashes"
+  )
+
   @doc """
   Renders a group of toasts and flashes.
 
@@ -229,6 +234,7 @@ defmodule LiveToast do
       group_class_fn={@group_class_fn}
       f={@flash}
       kinds={@kinds}
+      show_client_and_server_flashes={@show_client_and_server_flashes}
     />
     <Components.flash_group
       :if={!@connected}

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -52,6 +52,7 @@ defmodule LiveToast.Components do
       data-duration={@duration}
       data-corner={@corner}
       class={@toast_class_fn.(assigns)}
+      data-role={"{@kind}-toast"}
       {@rest}
     >
       <%= if @component do %>

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -52,7 +52,7 @@ defmodule LiveToast.Components do
       data-duration={@duration}
       data-corner={@corner}
       class={@toast_class_fn.(assigns)}
-      data-role={"{@kind}-toast"}
+      data-role={"#{@kind}-toast"}
       {@rest}
     >
       <%= if @component do %>

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -86,6 +86,7 @@ defmodule LiveToast.Components do
           "group-has-[[data-part='title']]/toast:absolute",
           "right-[5px] top-[5px] rounded-md p-[5px] text-black/50 transition-opacity hover:text-black focus:opacity-100 focus:outline-none focus:ring-1 group group-hover:opacity-100"
         ]}
+        data-role="close-toast-button"
         aria-label="close"
         {
         if Phoenix.Flash.get(@flash, @kind),

--- a/lib/live_toast/live_component.ex
+++ b/lib/live_toast/live_component.ex
@@ -37,7 +37,9 @@ defmodule LiveToast.LiveComponent do
 
   @impl Phoenix.LiveComponent
   def render(assigns) do
-    assigns = assign_new(assigns, :id, fn -> "toast-group" end)
+    assigns = assigns
+    |> assign_new(:id, fn -> "toast-group" end)
+    |> assign_new(:show_client_and_server_flashes, fn -> true end)
 
     ~H"""
     <div id={@id} class={@group_class_fn.(assigns)}>
@@ -71,7 +73,7 @@ defmodule LiveToast.LiveComponent do
         </Components.toast>
       </div>
 
-      <Components.flashes f={@f} corner={@corner} toast_class_fn={@toast_class_fn} kinds={@kinds} />
+      <Components.flashes :if={@show_client_and_server_flashes} f={@f} corner={@corner} toast_class_fn={@toast_class_fn} kinds={@kinds} />
     </div>
     """
   end

--- a/lib/live_toast/live_component.ex
+++ b/lib/live_toast/live_component.ex
@@ -43,7 +43,7 @@ defmodule LiveToast.LiveComponent do
 
     ~H"""
     <div id={@id} class={@group_class_fn.(assigns)}>
-      <div class="contents" id={@id <> "-stream"} phx-update="stream">
+      <div class="contents" id={@id <> "-stream"} phx-update="stream" data-role="toast-group-stream">
         <Components.toast
           :for={
             {dom_id,

--- a/lib/live_toast/live_component.ex
+++ b/lib/live_toast/live_component.ex
@@ -37,9 +37,11 @@ defmodule LiveToast.LiveComponent do
 
   @impl Phoenix.LiveComponent
   def render(assigns) do
+    assigns = assign_new(assigns, :id, fn -> "toast-group" end)
+
     ~H"""
-    <div id={assigns[:id] || "toast-group"} class={@group_class_fn.(assigns)}>
-      <div class="contents" id="toast-group-stream" phx-update="stream">
+    <div id={@id} class={@group_class_fn.(assigns)}>
+      <div class="contents" id={@id <> "-stream"} phx-update="stream">
         <Components.toast
           :for={
             {dom_id,

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule LiveToast.MixProject do
       {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},
       {:doctor, ">= 0.0.0", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.32.2", only: [:dev], runtime: false},
-      {:gettext, "~> 0.24.0"},
+      {:gettext, ">= 0.24.0"},
       {:mix_audit, ">= 0.0.0", only: [:dev], runtime: false},
       {:styler, "~> 0.11.9", only: [:dev, :test], runtime: false},
       {:makeup, "1.1.2", only: [:dev], runtime: false},


### PR DESCRIPTION
Just tweaks an HTML ID and adds conditional flash rendering.
This affords using toast group in `live_render`.
I also snuck in some cheeky `data-role` attributes for easier testing and CSS hacking.