### PR TITLE
fix: use String.Chars.t() instead of binary() for put_toast message

### DIFF
--- a/lib/live_toast.ex
+++ b/lib/live_toast.ex
@@ -100,12 +100,12 @@ defmodule LiveToast do
   """
   def put_toast(conn_or_socket, kind, msg, options \\ [])
 
-  @spec put_toast(Plug.Conn.t(), atom(), binary(), [option()]) :: Plug.Conn.t()
+  @spec put_toast(Plug.Conn.t(), atom(), String.Chars.t(), [option()]) :: Plug.Conn.t()
   def put_toast(%Plug.Conn{} = conn, kind, msg, _options) do
     Phoenix.Controller.put_flash(conn, kind, msg)
   end
 
-  @spec put_toast(LiveView.Socket.t(), atom(), binary(), [option()]) :: LiveView.Socket.t()
+  @spec put_toast(LiveView.Socket.t(), atom(), String.Chars.t(), [option()]) :: LiveView.Socket.t()
   def put_toast(%LiveView.Socket{} = socket, kind, msg, options) do
     send_toast(kind, msg, options)
 


### PR DESCRIPTION
The message does not have to be a binary, but needs to implement String.Chars for it to be rendered. This allows structs to be used like ErrorMessage without having to call to_string(error).