### PR TITLE
Update README with module name when invoking `put_toast/4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ application:
 ```elixir
 def deps do
   [
-    {:live_toast, "~> 0.6.4"}
+    {:live_toast, "~> 0.7"}
   ]
 end
 ```
@@ -153,7 +153,7 @@ Or you can use the helper function, [`put_toast`](https://hexdocs.pm/live_toast/
 defmodule YourApp.SomeLiveView do
   def handle_event("submit", _payload, socket) do
     socket = socket
-    |> put_toast(:info, "Upload successful.")
+    |> LiveToast.put_toast(:info, "Upload successful.")
 
     {:noreply, socket}
   end
@@ -167,7 +167,7 @@ non-live pages.
 defmodule YourApp.SomeController do
   def create(conn, _params) do
     conn
-    |> put_toast(:info, "Upload successful.")
+    |> LiveToast.put_toast(:info, "Upload successful.")
     |> render(:whatever)
   end
 end


### PR DESCRIPTION
- some of the README examples assumed that the `LiveToast` functions had been imported, so this adds the module name so that the examples work out of the box
- also updates the version to reflect the recent release