### PR TITLE
Update `source_ref` to point to default branch

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule LiveToast.MixProject do
     [
       main: "readme",
       extras: ["README.md", "CHANGELOG.md"],
-      source_ref: @version,
+      source_ref: "master",
       source_url: "https://github.com/srcrip/live_toast",
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
     ]


### PR DESCRIPTION
Hey there!

You don't seem to be using git tags, but your `source_ref` is set to a specific version. This results in 404 pages when trying to view the source from your docs:

![CleanShot 2025-02-08 at 16 24 24](https://github.com/user-attachments/assets/11920d3b-fb57-4019-b0bd-f21b851ebe07)

This merge request sets `source_ref` to master (default branch). This way you will be redirected to a valid GitHub page when you try to view the source.

The downside is that you will always be redirected to the latest version of the package (`master` branch), even if you are on an older docs page, but I guess it is better than being redirected to 404 pages.
