### PR TITLE
Support centered toast positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,15 @@ end
 
 ### Setting the corner
 
-You can change which corner the toasts are anchored to by passing the `corner` setting to `toast_group`, one of either `:top_left`, `:top_right`, `:bottom_left`, `:bottom_right`. The default is `:bottom_right`.
+You can change where toasts are anchored by passing the `corner` setting to `toast_group`. Supported positions are
+`:top_left`, `:top_center`, `:top_right`, `:bottom_left`, `:bottom_center`, and `:bottom_right`. The default is
+`:bottom_right`.
 
 ```heex
 <LiveToast.toast_group
   flash={@flash}
   connected={assigns[:socket] != nil}
-  corner={:top_right}
+  corner={:top_center}
   toasts_sync={assigns[:toasts_sync]}
 />
 ```

--- a/demo/lib/demo_web/live/home_live.ex
+++ b/demo/lib/demo_web/live/home_live.ex
@@ -122,6 +122,23 @@ defmodule DemoWeb.HomeLive do
     {:noreply, socket}
   end
 
+  def handle_event("show_centered_stack", %{"position" => position}, socket) do
+    {corner, label} = centered_position(position)
+
+    Enum.each(1..4, fn index ->
+      LiveToast.send_toast(
+        :info,
+        "#{label} stack item #{index}",
+        title: label,
+        duration: 8_000
+      )
+    end)
+
+    settings = Map.put(socket.assigns.settings, "corner", Atom.to_string(corner))
+
+    {:noreply, assign(socket, :settings, settings)}
+  end
+
   def handle_event("toast", payload, socket) do
     kind = Map.get(payload, "kind", "info")
     title = Map.get(payload, "title")
@@ -409,6 +426,9 @@ defmodule DemoWeb.HomeLive do
     </div>
     """
   end
+
+  defp centered_position("bottom"), do: {:bottom_center, "Bottom center"}
+  defp centered_position(_position), do: {:top_center, "Top center"}
 
   defp navbar(assigns) do
     ~H"""

--- a/demo/lib/demo_web/live/home_live.html.heex
+++ b/demo/lib/demo_web/live/home_live.html.heex
@@ -150,6 +150,12 @@
         >
           Pause Timed Toast
         </.link>
+        <.link
+          href={~p"/recipes#centered-positions"}
+          class="block mb-1 text-sm text-zinc-600 px-2 py-0.5 hover:text-zinc-900 hover:bg-zinc-100 rounded-md transition-colors"
+        >
+          Centered Positions
+        </.link>
       </div>
       <.link
         patch={~p"/customization"}

--- a/demo/lib/demo_web/live/tabs/demo.html.heex
+++ b/demo/lib/demo_web/live/tabs/demo.html.heex
@@ -148,7 +148,7 @@
     >
       can be anchored
     </.link>
-    to the top right, top left, bottom right, or bottom left of the screen.
+    to the top, bottom, or either side of the screen, including centered top and bottom positions.
   </p>
   <div class="flex flex-wrap gap-3">
     <.button

--- a/demo/lib/demo_web/live/tabs/recipes.html.heex
+++ b/demo/lib/demo_web/live/tabs/recipes.html.heex
@@ -97,3 +97,41 @@ LiveToast.dismiss_toast(uuid)</code></pre>
     </.button>
   </div>
 </div>
+
+<div class="mb-12 space-y-4">
+  <h3 id="centered-positions" class="scroll-mt-20 text-zinc-900 font-medium">
+    Centered Positions
+  </h3>
+  <p>
+    Use <code>corner={:top_center}</code>
+    or <code>corner={:bottom_center}</code>
+    to center the toast host along the top or bottom of the viewport. Both positions retain normal stacking and bounded overflow behavior.
+  </p>
+  <div class="flex flex-wrap gap-3">
+    <.button phx-click="show_centered_stack" phx-value-position="top">
+      Show Top-Center Stack
+    </.button>
+    <.button phx-click="show_centered_stack" phx-value-position="bottom">
+      Show Bottom-Center Stack
+    </.button>
+    <.button phx-click={JS.push("change_settings", value: %{"corner" => "bottom_right"})}>
+      Reset Position
+    </.button>
+  </div>
+  <pre class="overflow-x-auto rounded-md bg-zinc-950 p-4 text-sm text-zinc-100"><code>&lt;LiveToast.toast_group
+  flash=&#123;@flash&#125;
+  connected=&#123;assigns[:socket] != nil&#125;
+  toasts_sync=&#123;assigns[:toasts_sync]&#125;
+  corner=&#123;:top_center&#125;
+/&gt;
+
+# Or use corner=&#123;:bottom_center&#125;.</code></pre>
+  <p>
+    <.link
+      class="text-blue-700 hover:text-blue-500 underline"
+      href="https://github.com/srcrip/live_toast/blob/main/demo/lib/demo_web/components/layouts/app.html.heex"
+    >
+      View the host configuration
+    </.link>
+  </p>
+</div>

--- a/demo/test/demo_web/live/home_live_test.exs
+++ b/demo/test/demo_web/live/home_live_test.exs
@@ -82,6 +82,28 @@ defmodule DemoWeb.HomeLiveTest do
       assert render(view) =~ "data-live-toast-remaining"
     end
 
+    test "renders and exercises centered position recipe", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/recipes")
+
+      assert html =~ "Centered Positions"
+      assert html =~ "Show Top-Center Stack"
+      assert html =~ "Show Bottom-Center Stack"
+
+      view
+      |> element("button", "Show Top-Center Stack")
+      |> render_click()
+
+      assert render(view) =~ ~s(data-corner="top_center")
+      assert render(view) =~ "Top center stack item 4"
+
+      view
+      |> element("button", "Show Bottom-Center Stack")
+      |> render_click()
+
+      assert render(view) =~ ~s(data-corner="bottom_center")
+      assert render(view) =~ "Bottom center stack item 4"
+    end
+
     test "renders section links in the side navigation", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/recipes")
 
@@ -90,6 +112,7 @@ defmodule DemoWeb.HomeLiveTest do
       assert html =~ ~s(href="/recipes#showing-progress")
       assert html =~ ~s(href="/recipes#dismiss-programmatically")
       assert html =~ ~s(href="/recipes#pause-timed-toast")
+      assert html =~ ~s(href="/recipes#centered-positions")
     end
   end
 end

--- a/demo/test/demo_web/live/send_toast_test.exs
+++ b/demo/test/demo_web/live/send_toast_test.exs
@@ -53,6 +53,30 @@ defmodule DemoWeb.SendToastTest do
     end
   end
 
+  defmodule CenteredPositionLive do
+    @moduledoc false
+
+    use Phoenix.LiveView
+
+    def mount(_params, session, socket) do
+      {:ok, Phoenix.Component.assign(socket, :corner, centered_corner(session["corner"]))}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <LiveToast.toast_group
+        flash={@flash}
+        corner={@corner}
+        toasts_sync={assigns[:toasts_sync]}
+        connected={assigns[:socket] != nil}
+      />
+      """
+    end
+
+    defp centered_corner("bottom_center"), do: :bottom_center
+    defp centered_corner(_corner), do: :top_center
+  end
+
   describe "LiveToast.send_toast/3" do
     test "renders info toast", %{conn: conn} do
       {:ok, view, _html} = live_isolated(conn, TestLive)
@@ -87,6 +111,35 @@ defmodule DemoWeb.SendToastTest do
       })
 
       assert uuid =~ ~r/^[0-9a-f-]{36}$/
+    end
+  end
+
+  describe "centered positioning" do
+    for corner <- [:top_center, :bottom_center] do
+      test "renders a live host at #{corner}", %{conn: conn} do
+        {:ok, _view, html} =
+          live_isolated(conn, CenteredPositionLive, session: %{"corner" => unquote(Atom.to_string(corner))})
+
+        assert html =~ ~s(data-corner="#{unquote(Atom.to_string(corner))}")
+        assert html =~ "left-1/2"
+        assert html =~ unquote(if corner == :top_center, do: "top-0", else: "bottom-0")
+      end
+    end
+
+    test "renders dead-view hosts at both centered positions" do
+      Enum.each([:top_center, :bottom_center], fn corner ->
+        html =
+          render_component(&LiveToast.toast_group/1,
+            flash: %{},
+            connected: false,
+            toasts_sync: [],
+            corner: corner
+          )
+
+        assert html =~ ~s(data-corner="#{corner}")
+        assert html =~ "left-1/2"
+        assert html =~ if(corner == :top_center, do: "top-0", else: "bottom-0")
+      end)
     end
   end
 end

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -194,7 +194,7 @@ defmodule LiveToast.Components do
   attr(:kinds, :list, required: true, doc: "the valid severity level kinds")
 
   attr(:corner, :atom,
-    values: [:top_left, :top_right, :bottom_left, :bottom_right],
+    values: [:top_left, :top_center, :top_right, :bottom_left, :bottom_center, :bottom_right],
     default: :bottom_right,
     doc: "the corner to display the toasts"
   )


### PR DESCRIPTION
## Summary
- support `:top_center` and `:bottom_center` for dead-view toast hosts as well as LiveView hosts
- document all six supported toast positions
- add a recipe that previews bounded stacks at both centered positions

## Testing
- `MIX_ENV=test mix compile --force`
- `cd demo && MIX_ENV=test mix test`
- `cd assets && bun run typecheck`
- `cd assets && bun test`
- `cd assets && bunx biome check js test`