### PR TITLE
Support persistent toast durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,12 +268,22 @@ msgstr "Aguanta mientras volvemos a la normalidad"
 - `icon`: An optional function component that renders next to the title. You can use this with the default toast to display an icon.
 - `action`: An optional function component that renders to the side. You can use this with the default toast to display an action, like a button.
 - `duration`: How long the toast stays visible in milliseconds. Timed toasts pause while hovered or while keyboard focus
-    is inside the toast, then resume with their remaining duration. Set this to `0` to keep a toast visible until it is
-    dismissed. A custom component can include a `[data-live-toast-remaining]` element when it needs LiveToast to display
-    the remaining whole seconds.
+    is inside the toast, then resume with their remaining duration. Set this to `0` or `:infinity` to keep a toast visible
+    until it is dismissed. A custom component can include a `[data-live-toast-remaining]` element when it needs LiveToast
+    to display the remaining whole seconds.
 - `component`: Use this to totally override rendering of the toast. This is expected to be a function component that
     will receive all of the above options. See [this part of the demo](https://github.com/srcrip/live_toast/blob/fddcd7c51be05ba9997eb300ca920985e98ab583/demo/lib/demo_web/live/home_live.ex#L61) as an example.
 
+### Persistent toasts
+
+Pass `duration: 0` or `duration: :infinity` to disable automatic expiry. Persistent toasts can still be replaced with
+the same UUID and dismissed manually or programmatically.
+
+```elixir
+uuid = LiveToast.send_toast(:info, "Export ready", duration: :infinity)
+
+LiveToast.dismiss_toast(uuid)
+```
 Note that if you use more than just `:info` and `:error` in your codebase for flashes, you can augment LiveToast using
 some of the methods below to support that.
 

--- a/assets/js/live_toast/live_toast.ts
+++ b/assets/js/live_toast/live_toast.ts
@@ -13,6 +13,20 @@ function isFlash(el: HTMLElement) {
   return el.dataset.component === 'flash'
 }
 
+function parseDuration(value: string | undefined, fallback: number) {
+  if (value === undefined) {
+    return fallback
+  }
+
+  if (value === 'Infinity') {
+    return Number.POSITIVE_INFINITY
+  }
+
+  const parsed = Number.parseInt(value)
+
+  return Number.isNaN(parsed) ? fallback : parsed
+}
+
 // number of flashes that aren't hidden
 function flashCount() {
   let num = 0
@@ -405,10 +419,7 @@ export function createLiveToastHook(duration = 6000, maxItems = 3) {
       // begin actually showing the toast through this call to the animation function
       doAnimations.bind(this)(duration, maxItems)
 
-      let durationOverride = duration
-      if (this.el.dataset.duration !== undefined) {
-        durationOverride = Number.parseInt(this.el.dataset.duration)
-      }
+      const durationOverride = parseDuration(this.el.dataset.duration, duration)
 
       let flashDuration = undefined
       if (this.el.dataset.flashDuration !== undefined) {
@@ -434,8 +445,7 @@ export function createLiveToastHook(duration = 6000, maxItems = 3) {
           }
         }, flashDuration + removalTime)
       } else {
-        // you can set duration to 0 for infinite duration, basically
-        if (durationOverride !== 0) {
+        if (Number.isFinite(durationOverride) && durationOverride > 0) {
           startDismissTimer.bind(this)(durationOverride, duration, maxItems)
         }
       }

--- a/assets/test/live_toast.test.ts
+++ b/assets/test/live_toast.test.ts
@@ -50,7 +50,7 @@ function installDom() {
   return dom
 }
 
-function mountToast(duration = 1000, countdown = false) {
+function mountToast(duration: number | 'Infinity' = 1000, countdown = false) {
   document.body.innerHTML = `
     <div id="toast-group">
       <div id="toast-stream" phx-update="stream">
@@ -191,6 +191,14 @@ describe('LiveToast timed dismissal', () => {
 
   test('does not schedule dismissal for a persistent toast', () => {
     const toast = mountToast(0)
+
+    advance(60_000)
+
+    expect(toast.pushes).toHaveLength(0)
+  })
+
+  test('does not schedule dismissal for an Infinity duration', () => {
+    const toast = mountToast('Infinity')
 
     advance(60_000)
 

--- a/demo/lib/demo_web/live/home_live.ex
+++ b/demo/lib/demo_web/live/home_live.ex
@@ -139,6 +139,30 @@ defmodule DemoWeb.HomeLive do
     {:noreply, assign(socket, :settings, settings)}
   end
 
+  def handle_event("show_persistent_zero", _payload, socket) do
+    send_persistent_toast("persistent-zero", "Persistent with duration 0", 0)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("show_persistent_infinity", _payload, socket) do
+    send_persistent_toast("persistent-infinity", "Persistent with :infinity", :infinity)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("replace_persistent_infinity", _payload, socket) do
+    send_persistent_toast("persistent-infinity", "Persistent toast replaced", :infinity)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("dismiss_persistent_infinity", _payload, socket) do
+    LiveToast.dismiss_toast("persistent-infinity")
+
+    {:noreply, socket}
+  end
+
   def handle_event("toast", payload, socket) do
     kind = Map.get(payload, "kind", "info")
     title = Map.get(payload, "title")
@@ -425,6 +449,16 @@ defmodule DemoWeb.HomeLive do
       </p>
     </div>
     """
+  end
+
+  defp send_persistent_toast(uuid, body, duration) do
+    LiveToast.send_toast(
+      :info,
+      body,
+      uuid: uuid,
+      title: "Persistent toast",
+      duration: duration
+    )
   end
 
   defp centered_position("bottom"), do: {:bottom_center, "Bottom center"}

--- a/demo/lib/demo_web/live/home_live.html.heex
+++ b/demo/lib/demo_web/live/home_live.html.heex
@@ -156,6 +156,12 @@
         >
           Centered Positions
         </.link>
+        <.link
+          href={~p"/recipes#persistent-toasts"}
+          class="block mb-1 text-sm text-zinc-600 px-2 py-0.5 hover:text-zinc-900 hover:bg-zinc-100 rounded-md transition-colors"
+        >
+          Persistent Toasts
+        </.link>
       </div>
       <.link
         patch={~p"/customization"}

--- a/demo/lib/demo_web/live/tabs/recipes.html.heex
+++ b/demo/lib/demo_web/live/tabs/recipes.html.heex
@@ -135,3 +135,30 @@ LiveToast.dismiss_toast(uuid)</code></pre>
     </.link>
   </p>
 </div>
+
+<div class="mb-12 space-y-4">
+  <h3 id="persistent-toasts" class="scroll-mt-20 text-zinc-900 font-medium">
+    Persistent Toasts
+  </h3>
+  <p>
+    Set <code>duration: 0</code> or <code>duration: :infinity</code> to disable automatic expiry.
+    Persistent toasts can still be replaced with the same UUID or dismissed programmatically.
+  </p>
+  <div class="flex flex-wrap gap-3">
+    <.button phx-click="show_persistent_zero">Show duration: 0</.button>
+    <.button phx-click="show_persistent_infinity">Show :infinity</.button>
+    <.button phx-click="replace_persistent_infinity">Replace Persistent</.button>
+    <.button phx-click="dismiss_persistent_infinity">Dismiss Persistent</.button>
+  </div>
+  <pre class="overflow-x-auto rounded-md bg-zinc-950 p-4 text-sm text-zinc-100"><code>uuid = LiveToast.send_toast(:info, "Export ready", duration: :infinity)
+
+LiveToast.dismiss_toast(uuid)</code></pre>
+  <p>
+    <.link
+      class="text-blue-700 hover:text-blue-500 underline"
+      href="https://github.com/srcrip/live_toast/blob/main/demo/lib/demo_web/live/home_live.ex"
+    >
+      View the persistent toast example
+    </.link>
+  </p>
+</div>

--- a/demo/test/demo_web/live/home_live_test.exs
+++ b/demo/test/demo_web/live/home_live_test.exs
@@ -104,6 +104,41 @@ defmodule DemoWeb.HomeLiveTest do
       assert render(view) =~ "Bottom center stack item 4"
     end
 
+    test "supports both persistent duration forms", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/recipes")
+
+      assert html =~ "Persistent Toasts"
+
+      view
+      |> element("button", "Show duration: 0")
+      |> render_click()
+
+      assert render(view) =~ ~s(id="toast-persistent-zero")
+      assert render(view) =~ ~s(data-duration="0")
+
+      view
+      |> element("button", "Show :infinity")
+      |> render_click()
+
+      assert render(view) =~ ~s(id="toast-persistent-infinity")
+      assert render(view) =~ ~s(data-duration="Infinity")
+
+      view
+      |> element("button", "Replace Persistent")
+      |> render_click()
+
+      assert render(view) =~ "Persistent toast replaced"
+
+      view
+      |> element("button", "Dismiss Persistent")
+      |> render_click()
+
+      assert_push_event(view, "live-toast-dismiss", %{
+        id: "toast-persistent-infinity",
+        uuid: "persistent-infinity"
+      })
+    end
+
     test "renders section links in the side navigation", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/recipes")
 
@@ -113,6 +148,7 @@ defmodule DemoWeb.HomeLiveTest do
       assert html =~ ~s(href="/recipes#dismiss-programmatically")
       assert html =~ ~s(href="/recipes#pause-timed-toast")
       assert html =~ ~s(href="/recipes#centered-positions")
+      assert html =~ ~s(href="/recipes#persistent-toasts")
     end
   end
 end

--- a/lib/live_toast.ex
+++ b/lib/live_toast.ex
@@ -31,7 +31,7 @@ defmodule LiveToast do
             icon: component_fn() | nil,
             action: component_fn() | nil,
             component: component_fn() | nil,
-            duration: non_neg_integer() | nil,
+            duration: duration() | nil,
             container_id: binary() | nil,
             uuid: Ecto.UUID.t() | nil,
             sync: boolean() | nil
@@ -40,13 +40,16 @@ defmodule LiveToast do
   @typedoc "`Phoenix.Component` that renders a part of the toast message."
   @type component_fn() :: (map() -> Phoenix.LiveView.Rendered.t())
 
+  @typedoc "Milliseconds before expiry, or `:infinity` for a persistent toast."
+  @type duration() :: non_neg_integer() | :infinity
+
   @typedoc "Set of public options to augment the default toast behavior."
   @type option() ::
           {:title, binary() | nil}
           | {:icon, component_fn() | nil}
           | {:action, component_fn() | nil}
           | {:component, component_fn() | nil}
-          | {:duration, non_neg_integer() | nil}
+          | {:duration, duration() | nil}
           | {:container_id, binary() | nil}
           | {:uuid, Ecto.UUID.t() | nil}
           | {:sync, boolean() | nil}

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -22,7 +22,7 @@ defmodule LiveToast.Components do
     doc: "adds a delay before being shown. not exposed by default, used only for 'client-error' and 'server-error'"
   )
 
-  attr(:duration, :integer,
+  attr(:duration, :any,
     default: 6000,
     doc: "the time in milliseconds before the message is automatically dismissed"
   )
@@ -59,7 +59,7 @@ defmodule LiveToast.Components do
       phx-hook="LiveToast"
       data-kind={@kind}
       data-flash-duration={@flash_duration}
-      data-duration={@duration}
+      data-duration={duration_value(@duration)}
       data-delay={@delay}
       data-corner={@corner}
       class={@toast_class_fn.(assigns)}
@@ -188,6 +188,9 @@ defmodule LiveToast.Components do
     </.toast>
     """
   end
+
+  defp duration_value(:infinity), do: "Infinity"
+  defp duration_value(duration), do: duration
 
   attr(:flash, :map, required: true, doc: "the map of flash messages")
   attr(:id, :string, default: "toast-group", doc: "the optional id of flash container")


### PR DESCRIPTION
## Summary
- accept `duration: :infinity` as an explicit persistent-toast alias alongside `duration: 0`
- preserve replacement and manual/programmatic dismissal for both persistent forms
- document and demonstrate both supported forms in the recipe

## Testing
- `MIX_ENV=test mix compile --force`
- `mix format --check-formatted`
- `cd demo && MIX_ENV=test mix test`
- `cd assets && bun run typecheck`
- `cd assets && bun test`
- `cd assets && bunx biome check js test`