### PR TITLE
Make connection notifications customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,32 @@ uuid = LiveToast.send_toast(:info, "Export ready", duration: :infinity)
 
 LiveToast.dismiss_toast(uuid)
 ```
+
+### Connection-state notifications
+
+Customize the built-in client and server connection notices with `connection_notifications`. Each entry accepts
+`kind`, `title`, and `body`; unspecified values retain their defaults. Notices are persistent, non-dismissible, and
+excluded from the ordinary visible-toast limit.
+
+Use the optional `:client_error` and `:server_error` slots when an application needs custom markup. LiveToast retains
+the connection-event wiring, animation, and toast shell while the slot receives `id`, `kind`, `title`, `body`, and
+`corner` through `:let`.
+
+```heex
+<LiveToast.toast_group
+  flash={@flash}
+  connected={assigns[:socket] != nil}
+  toasts_sync={assigns[:toasts_sync]}
+  connection_notifications={%{
+    client_error: %{kind: :info, title: "Reconnecting", body: "Your changes are safe."}
+  }}
+>
+  <:client_error :let={notice}>
+    <.reconnecting_notice title={notice.title} body={notice.body} />
+  </:client_error>
+</LiveToast.toast_group>
+```
+
 Note that if you use more than just `:info` and `:error` in your codebase for flashes, you can augment LiveToast using
 some of the methods below to support that.
 

--- a/demo/lib/demo_web/components/layouts.ex
+++ b/demo/lib/demo_web/components/layouts.ex
@@ -33,4 +33,22 @@ defmodule DemoWeb.Layouts do
       assigns[:corner] == :top_right && "items-start top-0 right-0 flex-col sm:bottom-auto"
     ]
   end
+
+  attr(:notice, :map, required: true)
+
+  def connection_notice(assigns) do
+    ~H"""
+    <div
+      class="grid w-full grid-cols-[auto_1fr] items-center gap-3"
+      data-connection-notice-id={@notice.id}
+      data-connection-notice-kind={@notice.kind}
+    >
+      <span class="size-2 rounded-full bg-sky-500 motion-safe:animate-pulse"></span>
+      <div>
+        <p class="text-sm font-semibold text-zinc-900">{@notice.title}</p>
+        <p class="text-sm text-zinc-600">{@notice.body}</p>
+      </div>
+    </div>
+    """
+  end
 end

--- a/demo/lib/demo_web/components/layouts/app.html.heex
+++ b/demo/lib/demo_web/components/layouts/app.html.heex
@@ -5,6 +5,19 @@
     flash={@flash}
     kinds={[:info, :error, :warn]}
     flash_duration={3000}
+    connection_notifications={
+      if assigns[:live_action] == :recipes do
+        %{
+          client_error: %{
+            kind: :info,
+            title: "Connection interrupted",
+            body: "Live updates will resume automatically."
+          }
+        }
+      else
+        %{}
+      end
+    }
     toasts_sync={assigns[:toasts_sync]}
     connected={assigns[:socket] != nil}
     {
@@ -23,5 +36,10 @@
         []
       end
     }
-  /> {@inner_content}
+  >
+    <:client_error :let={notice} :if={assigns[:live_action] == :recipes}>
+      <.connection_notice notice={notice} />
+    </:client_error>
+  </LiveToast.toast_group>
+  {@inner_content}
 </div>

--- a/demo/lib/demo_web/live/home_live.html.heex
+++ b/demo/lib/demo_web/live/home_live.html.heex
@@ -162,6 +162,12 @@
         >
           Persistent Toasts
         </.link>
+        <.link
+          href={~p"/recipes#connection-notifications"}
+          class="block mb-1 text-sm text-zinc-600 px-2 py-0.5 hover:text-zinc-900 hover:bg-zinc-100 rounded-md transition-colors"
+        >
+          Connection Notices
+        </.link>
       </div>
       <.link
         patch={~p"/customization"}

--- a/demo/lib/demo_web/live/tabs/recipes.html.heex
+++ b/demo/lib/demo_web/live/tabs/recipes.html.heex
@@ -162,3 +162,40 @@ LiveToast.dismiss_toast(uuid)</code></pre>
     </.link>
   </p>
 </div>
+
+<div class="mb-12 space-y-4">
+  <h3 id="connection-notifications" class="scroll-mt-20 text-zinc-900 font-medium">
+    Customize Connection Notices
+  </h3>
+  <p>
+    Change the built-in notice copy and kind, or provide custom content with named slots. LiveToast continues to manage connection events, animation, persistence, and stacking.
+  </p>
+  <div class="flex flex-wrap gap-3">
+    <.button phx-click={JS.dispatch("show-error", to: "#client-error")}>
+      Preview Custom Notice
+    </.button>
+    <.button phx-click={JS.dispatch("hide-error", to: "#client-error")}>
+      Hide Preview
+    </.button>
+  </div>
+  <pre class="overflow-x-auto rounded-md bg-zinc-950 p-4 text-sm text-zinc-100"><code>&lt;LiveToast.toast_group
+  flash=&#123;@flash&#125;
+  connected=&#123;assigns[:socket] != nil&#125;
+  toasts_sync=&#123;assigns[:toasts_sync]&#125;
+  connection_notifications=&#123;%&#123;
+    client_error: %&#123;kind: :info, title: "Reconnecting", body: "Your changes are safe."&#125;
+  &#125;&#125;
+&gt;
+  &lt;:client_error :let=&#123;notice&#125;&gt;
+    &lt;.reconnecting_notice title=&#123;notice.title&#125; body=&#123;notice.body&#125; /&gt;
+  &lt;/:client_error&gt;
+&lt;/LiveToast.toast_group&gt;</code></pre>
+  <p>
+    <.link
+      class="text-blue-700 hover:text-blue-500 underline"
+      href="https://github.com/srcrip/live_toast/blob/main/demo/lib/demo_web/components/layouts/app.html.heex"
+    >
+      View the host configuration
+    </.link>
+  </p>
+</div>

--- a/demo/test/demo_web/live/home_live_test.exs
+++ b/demo/test/demo_web/live/home_live_test.exs
@@ -104,6 +104,17 @@ defmodule DemoWeb.HomeLiveTest do
       assert render(view) =~ "Bottom center stack item 4"
     end
 
+    test "renders the custom connection notice recipe", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/recipes")
+
+      assert html =~ "Customize Connection Notices"
+      assert html =~ "Preview Custom Notice"
+      assert html =~ ~s(data-live-toast-connection="client_error")
+      assert html =~ ~s(data-connection-notice-id="client-error")
+      assert html =~ "Connection interrupted"
+      refute has_element?(view, "#client-error button[aria-label=close]")
+    end
+
     test "supports both persistent duration forms", %{conn: conn} do
       {:ok, view, html} = live(conn, ~p"/recipes")
 
@@ -149,6 +160,7 @@ defmodule DemoWeb.HomeLiveTest do
       assert html =~ ~s(href="/recipes#pause-timed-toast")
       assert html =~ ~s(href="/recipes#centered-positions")
       assert html =~ ~s(href="/recipes#persistent-toasts")
+      assert html =~ ~s(href="/recipes#connection-notifications")
     end
   end
 end

--- a/demo/test/demo_web/live/send_toast_test.exs
+++ b/demo/test/demo_web/live/send_toast_test.exs
@@ -1,5 +1,6 @@
 defmodule DemoWeb.SendToastTest do
   use DemoWeb.ConnCase
+  use Phoenix.Component
 
   import Phoenix.LiveViewTest
 
@@ -77,6 +78,57 @@ defmodule DemoWeb.SendToastTest do
     defp centered_corner(_corner), do: :top_center
   end
 
+  defmodule ConnectionNotificationLive do
+    @moduledoc false
+
+    use Phoenix.LiveView
+
+    def mount(_params, _session, socket), do: {:ok, socket}
+
+    def render(assigns) do
+      ~H"""
+      <LiveToast.toast_group
+        flash={@flash}
+        connected={assigns[:socket] != nil}
+        toasts_sync={assigns[:toasts_sync]}
+        connection_notifications={
+          %{
+            client_error: %{kind: :info, title: "Custom title", body: "Custom body"}
+          }
+        }
+      >
+        <:client_error :let={notice}>
+          <div id="custom-client-notice" data-notice-id={notice.id} data-notice-kind={notice.kind}>
+            <span>{notice.title}</span>
+            <span>{notice.body}</span>
+          </div>
+        </:client_error>
+      </LiveToast.toast_group>
+      """
+    end
+  end
+
+  attr :flash, :map, required: true
+  attr :toasts_sync, :list, required: true
+
+  defp dead_connection_notification_host(assigns) do
+    ~H"""
+    <LiveToast.toast_group
+      flash={@flash}
+      connected={false}
+      toasts_sync={@toasts_sync}
+      connection_notifications={%{server_error: %{title: "Offline", body: "Trying again"}}}
+    >
+      <:server_error :let={notice}>
+        <div id="custom-server-notice" data-notice-id={notice.id}>
+          <span>{notice.title}</span>
+          <span>{notice.body}</span>
+        </div>
+      </:server_error>
+    </LiveToast.toast_group>
+    """
+  end
+
   describe "LiveToast.send_toast/3" do
     test "renders info toast", %{conn: conn} do
       {:ok, view, _html} = live_isolated(conn, TestLive)
@@ -140,6 +192,33 @@ defmodule DemoWeb.SendToastTest do
         assert html =~ "left-1/2"
         assert html =~ if(corner == :top_center, do: "top-0", else: "bottom-0")
       end)
+    end
+  end
+
+  describe "connection notification slots" do
+    test "renders custom client notice content in a live host", %{conn: conn} do
+      {:ok, view, html} = live_isolated(conn, ConnectionNotificationLive)
+
+      assert html =~ ~s(data-live-toast-connection="client_error")
+      assert html =~ ~s(data-notice-id="client-error")
+      assert html =~ ~s(data-notice-kind="info")
+      assert html =~ "Custom title"
+      assert html =~ "Custom body"
+      refute has_element?(view, "#client-error button[aria-label=close]")
+    end
+
+    test "renders custom server notice content in a dead host" do
+      html =
+        render_component(&dead_connection_notification_host/1,
+          flash: %{},
+          toasts_sync: []
+        )
+
+      assert html =~ ~s(data-live-toast-connection="server_error")
+      assert html =~ ~s(data-notice-id="server-error")
+      assert html =~ "Offline"
+      assert html =~ "Trying again"
+      refute html =~ ~s(aria-label="close")
     end
   end
 end

--- a/lib/live_toast.ex
+++ b/lib/live_toast.ex
@@ -294,6 +294,14 @@ defmodule LiveToast do
 
   attr :client_error_delay, :integer, default: 3000, doc: "adds a delay before the disconnected client error is shown"
 
+  attr(:connection_notifications, :map,
+    default: %{},
+    doc: "copy and kind overrides for connection-state notifications"
+  )
+
+  slot(:client_error, doc: "optional custom content for the client connection notice")
+  slot(:server_error, doc: "optional custom content for the server connection notice")
+
   @doc """
   Renders a group of toasts and flashes.
 
@@ -308,8 +316,12 @@ defmodule LiveToast do
       toasts_sync={@toasts_sync}
       corner={@corner}
       flash_duration={@flash_duration}
+      client_error_delay={@client_error_delay}
       toast_class_fn={@toast_class_fn}
       group_class_fn={@group_class_fn}
+      connection_notifications={@connection_notifications}
+      client_error={@client_error}
+      server_error={@server_error}
       f={@flash}
       kinds={@kinds}
     />
@@ -321,6 +333,9 @@ defmodule LiveToast do
       toast_class_fn={@toast_class_fn}
       group_class_fn={@group_class_fn}
       client_error_delay={@client_error_delay}
+      connection_notifications={@connection_notifications}
+      client_error={@client_error}
+      server_error={@server_error}
       flash={@flash}
       kinds={@kinds}
     />

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -37,6 +37,7 @@ defmodule LiveToast.Components do
   attr(:icon, :any, default: nil, doc: "the optional icon to render in the flash message")
   attr(:action, :any, default: nil, doc: "the optional action to render in the flash message")
   attr(:component, :any, default: nil, doc: "the optional component to render the flash message")
+  attr(:dismissible, :boolean, default: true, doc: "whether the toast can be dismissed manually")
 
   attr(:flash_duration, :integer, default: 0, doc: "if provided clears flash after provided milliseconds")
 
@@ -92,6 +93,7 @@ defmodule LiveToast.Components do
         <% end %>
       <% end %>
       <button
+        :if={@dismissible}
         type="button"
         class={[
           "group-has-[[data-part='title']]/toast:absolute",
@@ -130,12 +132,22 @@ defmodule LiveToast.Components do
     doc: "function to override the toast classes"
   )
 
+  attr(:connection_notifications, :map,
+    default: %{},
+    doc: "copy and kind overrides for connection-state notifications"
+  )
+
+  attr(:client_error, :list, default: [], doc: "optional custom content for the client connection notice")
+  attr(:server_error, :list, default: [], doc: "optional custom content for the server connection notice")
+
   attr(:kinds, :list, required: true, doc: "the valid severity level kinds")
 
   attr(:flash_duration, :integer, default: 0, doc: "if provided clears flash after provided milliseconds")
 
   @doc false
   def flashes(assigns) do
+    assigns = assign(assigns, :connection_notifications, connection_notifications(assigns.connection_notifications))
+
     ~H"""
     <.toast
       :for={level <- @kinds}
@@ -154,8 +166,11 @@ defmodule LiveToast.Components do
       corner={@corner}
       toast_class_fn={@toast_class_fn}
       id="client-error"
-      kind={:error}
-      title={Utility.translate("We can't find the internet")}
+      kind={@connection_notifications.client_error.kind}
+      title={Utility.translate(@connection_notifications.client_error.title)}
+      duration={0}
+      dismissible={false}
+      data-live-toast-connection="client_error"
       delay={@client_error_delay}
       phx-update="ignore"
       phx-disconnected={Utility.show_error(".phx-client-error #client-error")}
@@ -164,8 +179,15 @@ defmodule LiveToast.Components do
       data-connected={Utility.hide("#client-error")}
       hidden
     >
-      {Utility.translate("Attempting to reconnect")}
-      <Utility.svg name="hero-arrow-path" class="inline-block ml-1 h-3 w-3 animate-spin" />
+      <%= if @client_error == [] do %>
+        {Utility.translate(@connection_notifications.client_error.body)}
+        <Utility.svg name="hero-arrow-path" class="inline-block ml-1 h-3 w-3 animate-spin" />
+      <% else %>
+        {render_slot(
+          @client_error,
+          connection_notice_assigns(@connection_notifications.client_error, "client-error", @corner)
+        )}
+      <% end %>
     </.toast>
 
     <.toast
@@ -173,8 +195,11 @@ defmodule LiveToast.Components do
       corner={@corner}
       toast_class_fn={@toast_class_fn}
       id="server-error"
-      kind={:error}
-      title={Utility.translate("Something went wrong!")}
+      kind={@connection_notifications.server_error.kind}
+      title={Utility.translate(@connection_notifications.server_error.title)}
+      duration={0}
+      dismissible={false}
+      data-live-toast-connection="server_error"
       phx-update="ignore"
       phx-disconnected={Utility.show_error(".phx-server-error #server-error")}
       phx-connected={Utility.hide_error("#server-error")}
@@ -183,8 +208,15 @@ defmodule LiveToast.Components do
       delay={@client_error_delay}
       hidden
     >
-      {Utility.translate("Hang in there while we get back on track")}
-      <Utility.svg name="hero-arrow-path" class="inline-block ml-1 h-3 w-3 animate-spin" />
+      <%= if @server_error == [] do %>
+        {Utility.translate(@connection_notifications.server_error.body)}
+        <Utility.svg name="hero-arrow-path" class="inline-block ml-1 h-3 w-3 animate-spin" />
+      <% else %>
+        {render_slot(
+          @server_error,
+          connection_notice_assigns(@connection_notifications.server_error, "server-error", @corner)
+        )}
+      <% end %>
     </.toast>
     """
   end
@@ -216,6 +248,14 @@ defmodule LiveToast.Components do
 
   attr(:flash_duration, :integer, default: 0, doc: "if provided clears flash after provided milliseconds")
 
+  attr(:connection_notifications, :map,
+    default: %{},
+    doc: "copy and kind overrides for connection-state notifications"
+  )
+
+  attr(:client_error, :list, default: [], doc: "optional custom content for the client connection notice")
+  attr(:server_error, :list, default: [], doc: "optional custom content for the server connection notice")
+
   # Used to render flashes-only on regular non-LV pages.
   @doc false
   def flash_group(assigns) do
@@ -226,9 +266,36 @@ defmodule LiveToast.Components do
         corner={@corner}
         flash_duration={@flash_duration}
         toast_class_fn={@toast_class_fn}
+        client_error_delay={@client_error_delay}
+        connection_notifications={@connection_notifications}
+        client_error={@client_error}
+        server_error={@server_error}
         kinds={@kinds}
       />
     </div>
     """
+  end
+
+  defp connection_notifications(overrides) do
+    defaults = %{
+      client_error: %{
+        kind: :error,
+        title: "We can't find the internet",
+        body: "Attempting to reconnect"
+      },
+      server_error: %{
+        kind: :error,
+        title: "Something went wrong!",
+        body: "Hang in there while we get back on track"
+      }
+    }
+
+    Map.new(defaults, fn {name, notification} ->
+      {name, Map.merge(notification, Map.get(overrides, name, %{}))}
+    end)
+  end
+
+  defp connection_notice_assigns(notification, id, corner) do
+    Map.merge(notification, %{id: id, corner: corner})
   end
 end

--- a/lib/live_toast/live_component.ex
+++ b/lib/live_toast/live_component.ex
@@ -132,6 +132,10 @@ defmodule LiveToast.LiveComponent do
         corner={@corner}
         flash_duration={@flash_duration}
         toast_class_fn={@toast_class_fn}
+        client_error_delay={@client_error_delay}
+        connection_notifications={@connection_notifications}
+        client_error={@client_error}
+        server_error={@server_error}
         kinds={@kinds}
       />
     </div>


### PR DESCRIPTION
## Summary
- add copy and semantic-kind overrides for the built-in connection notices
- add client and server named slots while preserving LiveToast event wiring, animation, persistence, and stacking
- document the API and add an interactive demo recipe linked to the demo host configuration

## Validation
- `MIX_ENV=test mix compile --force`
- `mix format --check-formatted`
- `cd demo && MIX_ENV=test mix test`
- `cd assets && bun run typecheck && bun test && bunx biome check js test`