### PR TITLE
Add metadata for custom toast components

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,36 @@ msgstr "Aguanta mientras volvemos a la normalidad"
     to display the remaining whole seconds.
 - `component`: Use this to totally override rendering of the toast. This is expected to be a function component that
     will receive all of the above options. See [this part of the demo](https://github.com/srcrip/live_toast/blob/fddcd7c51be05ba9997eb300ca920985e98ab583/demo/lib/demo_web/live/home_live.ex#L61) as an example.
+- `metadata`: An application-defined map passed unchanged to a custom `component` function. Use this for
+    component-specific presentation or behavior without adding library-level options. LiveToast does not interpret
+    metadata.
+
+### Custom component metadata
+
+Custom component functions receive `metadata` alongside the standard toast assigns such as `kind`, `title`, `body`,
+`uuid`, `duration`, and `dismissible`. This gives an application a stable extension point for renderer-specific options.
+
+For example, a component can show its semantic icon by default and let individual toasts opt out:
+
+```elixir
+def notification_toast(assigns) do
+  ~H"""
+  <div>
+    <span :if={Map.get(@metadata, :has_icon, true)} aria-hidden="true">*</span>
+    <p :if={@title} data-part="title">{@title}</p>
+    <p>{@body}</p>
+  </div>
+  """
+end
+
+LiveToast.send_toast(
+  :info,
+  "The message was sent.",
+  title: "Sent",
+  component: &notification_toast/1,
+  metadata: %{has_icon: false}
+)
+```
 
 ### Persistent toasts
 

--- a/demo/lib/demo_web/live/home_live.ex
+++ b/demo/lib/demo_web/live/home_live.ex
@@ -122,6 +122,20 @@ defmodule DemoWeb.HomeLive do
     {:noreply, socket}
   end
 
+  def handle_event("show_conditional_icon_toast", %{"has_icon" => has_icon}, socket) do
+    LiveToast.send_toast(
+      :info,
+      "This custom component reads its icon setting from application metadata.",
+      title: "Conditional custom rendering",
+      component: &conditional_icon_toast/1,
+      metadata: %{has_icon: has_icon == "true"},
+      duration: 8_000,
+      uuid: "conditional-icon-recipe"
+    )
+
+    {:noreply, socket}
+  end
+
   def handle_event("show_centered_stack", %{"position" => position}, socket) do
     {corner, label} = centered_position(position)
 
@@ -400,6 +414,26 @@ defmodule DemoWeb.HomeLive do
       >
         Dismiss in component
       </button>
+    </div>
+    """
+  end
+
+  def conditional_icon_toast(assigns) do
+    ~H"""
+    <div class="grow flex flex-col items-start justify-center">
+      <p :if={@title} data-part="title" class="mb-2 flex items-center text-sm font-semibold leading-6">
+        <span
+          :if={Map.get(@metadata, :has_icon, true)}
+          aria-hidden="true"
+          class="mr-1.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-emerald-500 text-xs text-white"
+        >
+          &check;
+        </span>
+        {@title}
+      </p>
+      <p class="text-sm leading-5">
+        {@body}
+      </p>
     </div>
     """
   end

--- a/demo/lib/demo_web/live/home_live.html.heex
+++ b/demo/lib/demo_web/live/home_live.html.heex
@@ -151,6 +151,12 @@
           Pause Timed Toast
         </.link>
         <.link
+          href={~p"/recipes#conditional-custom-rendering"}
+          class="block mb-1 text-sm text-zinc-600 px-2 py-0.5 hover:text-zinc-900 hover:bg-zinc-100 rounded-md transition-colors"
+        >
+          Conditional Custom Rendering
+        </.link>
+        <.link
           href={~p"/recipes#centered-positions"}
           class="block mb-1 text-sm text-zinc-600 px-2 py-0.5 hover:text-zinc-900 hover:bg-zinc-100 rounded-md transition-colors"
         >

--- a/demo/lib/demo_web/live/tabs/recipes.html.heex
+++ b/demo/lib/demo_web/live/tabs/recipes.html.heex
@@ -99,6 +99,50 @@ LiveToast.dismiss_toast(uuid)</code></pre>
 </div>
 
 <div class="mb-12 space-y-4">
+  <h3 id="conditional-custom-rendering" class="scroll-mt-20 text-zinc-900 font-medium">
+    Conditional Rendering in Custom Component Functions
+  </h3>
+  <p>
+    Pass application-specific data with <code>metadata</code>
+    when a custom component needs per-toast rendering behavior.
+    LiveToast preserves this map without interpreting it.
+  </p>
+  <div class="flex flex-wrap gap-3">
+    <.button phx-click="show_conditional_icon_toast" phx-value-has_icon="true">
+      Show With Icon
+    </.button>
+    <.button phx-click="show_conditional_icon_toast" phx-value-has_icon="false">
+      Show Without Icon
+    </.button>
+  </div>
+  <pre class="overflow-x-auto rounded-md bg-zinc-950 p-4 text-sm text-zinc-100"><code>LiveToast.send_toast(
+  :info,
+  "The message was sent.",
+  title: "Sent",
+  component: &amp;notification_toast/1,
+  metadata: %&#123;has_icon: false&#125;
+)
+
+def notification_toast(assigns) do
+  ~H"""
+  &lt;div&gt;
+    &lt;span :if=&#123;Map.get(@metadata, :has_icon, true)&#125;&gt;*&lt;/span&gt;
+    &lt;p :if=&#123;@title&#125; data-part="title"&gt;&#123;@title&#125;&lt;/p&gt;
+    &lt;p&gt;&#123;@body&#125;&lt;/p&gt;
+  &lt;/div&gt;
+  """
+end</code></pre>
+  <p>
+    <.link
+      class="text-blue-700 hover:text-blue-500 underline"
+      href="https://github.com/srcrip/live_toast/blob/main/demo/lib/demo_web/live/home_live.ex"
+    >
+      View the demo source
+    </.link>
+  </p>
+</div>
+
+<div class="mb-12 space-y-4">
   <h3 id="centered-positions" class="scroll-mt-20 text-zinc-900 font-medium">
     Centered Positions
   </h3>

--- a/demo/test/demo_web/live/home_live_test.exs
+++ b/demo/test/demo_web/live/home_live_test.exs
@@ -82,6 +82,28 @@ defmodule DemoWeb.HomeLiveTest do
       assert render(view) =~ "data-live-toast-remaining"
     end
 
+    test "renders and exercises conditional custom rendering recipe", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/recipes")
+
+      assert html =~ "Conditional Rendering in Custom Component Functions"
+      assert html =~ "metadata: %{has_icon: false}"
+      assert html =~ "View the demo source"
+
+      view
+      |> element("button", "Show With Icon")
+      |> render_click()
+
+      assert render(view) =~ ~s(data-part="title")
+      assert render(view) =~ "Conditional custom rendering"
+      assert render(view) =~ "bg-emerald-500"
+
+      view
+      |> element("button", "Show Without Icon")
+      |> render_click()
+
+      refute render(view) =~ "bg-emerald-500"
+    end
+
     test "renders and exercises centered position recipe", %{conn: conn} do
       {:ok, view, html} = live(conn, ~p"/recipes")
 

--- a/demo/test/demo_web/live/send_toast_test.exs
+++ b/demo/test/demo_web/live/send_toast_test.exs
@@ -37,6 +37,19 @@ defmodule DemoWeb.SendToastTest do
       {:noreply, socket}
     end
 
+    def handle_event("send_metadata_toast", %{"has_icon" => has_icon}, socket) do
+      LiveToast.send_toast(
+        :info,
+        "Metadata controls this custom component.",
+        title: "Custom metadata",
+        component: &metadata_toast/1,
+        metadata: %{has_icon: has_icon == "true", reference: "receipt-123"},
+        uuid: "metadata-toast"
+      )
+
+      {:noreply, socket}
+    end
+
     def render(assigns) do
       ~H"""
       <LiveToast.toast_group
@@ -49,6 +62,23 @@ defmodule DemoWeb.SendToastTest do
         <button phx-click="send_error">Send Error Toast</button>
         <button phx-click="send_persistent">Send Persistent Toast</button>
         <button phx-click="dismiss_persistent">Dismiss Persistent Toast</button>
+        <button phx-click="send_metadata_toast" phx-value-has_icon="true">
+          Send Metadata Toast With Icon
+        </button>
+        <button phx-click="send_metadata_toast" phx-value-has_icon="false">
+          Send Metadata Toast Without Icon
+        </button>
+      </div>
+      """
+    end
+
+    defp metadata_toast(assigns) do
+      ~H"""
+      <div>
+        <span :if={Map.get(@metadata, :has_icon, true)} data-metadata-icon>Icon</span>
+        <p data-part="title">{@title}</p>
+        <p>{@body}</p>
+        <span data-reference={@metadata.reference}></span>
       </div>
       """
     end
@@ -163,6 +193,28 @@ defmodule DemoWeb.SendToastTest do
       })
 
       assert uuid =~ ~r/^[0-9a-f-]{36}$/
+    end
+
+    test "passes application metadata to a custom toast component", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, TestLive)
+
+      view
+      |> element("button", "Send Metadata Toast With Icon")
+      |> render_click()
+
+      html = render(view)
+
+      assert html =~ ~s(data-metadata-icon)
+      assert html =~ ~s(data-reference="receipt-123")
+
+      view
+      |> element("button", "Send Metadata Toast Without Icon")
+      |> render_click()
+
+      html = render(view)
+
+      refute html =~ ~s(data-metadata-icon)
+      assert html =~ ~s(data-reference="receipt-123")
     end
   end
 

--- a/lib/live_toast.ex
+++ b/lib/live_toast.ex
@@ -17,6 +17,7 @@ defmodule LiveToast do
     :icon,
     :action,
     :component,
+    :metadata,
     :duration,
     :container_id,
     :uuid,
@@ -31,6 +32,7 @@ defmodule LiveToast do
             icon: component_fn() | nil,
             action: component_fn() | nil,
             component: component_fn() | nil,
+            metadata: map(),
             duration: duration() | nil,
             container_id: binary() | nil,
             uuid: Ecto.UUID.t() | nil,
@@ -49,6 +51,7 @@ defmodule LiveToast do
           | {:icon, component_fn() | nil}
           | {:action, component_fn() | nil}
           | {:component, component_fn() | nil}
+          | {:metadata, map()}
           | {:duration, duration() | nil}
           | {:container_id, binary() | nil}
           | {:uuid, Ecto.UUID.t() | nil}
@@ -67,6 +70,7 @@ defmodule LiveToast do
       icon: options[:icon],
       action: options[:action],
       component: options[:component],
+      metadata: options[:metadata] || %{},
       duration: options[:duration],
       container_id: container_id,
       uuid: uuid,
@@ -79,6 +83,9 @@ defmodule LiveToast do
 
   Returns the UUID of the new toast message. This UUID can be passed back
   to another call to `send_toast/3` to update the properties of an existing toast.
+
+  Use the `:metadata` option to provide application-defined data to a custom
+  component function. LiveToast preserves this map without interpreting it.
 
   ## Examples
 

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -37,6 +37,7 @@ defmodule LiveToast.Components do
   attr(:icon, :any, default: nil, doc: "the optional icon to render in the flash message")
   attr(:action, :any, default: nil, doc: "the optional action to render in the flash message")
   attr(:component, :any, default: nil, doc: "the optional component to render the flash message")
+  attr(:metadata, :map, default: %{}, doc: "application-defined data passed to a custom toast component")
   attr(:dismissible, :boolean, default: true, doc: "whether the toast can be dismissed manually")
 
   attr(:flash_duration, :integer, default: 0, doc: "if provided clears flash after provided milliseconds")

--- a/lib/live_toast/live_component.ex
+++ b/lib/live_toast/live_component.ex
@@ -105,6 +105,7 @@ defmodule LiveToast.LiveComponent do
                title: title,
                icon: icon,
                action: action,
+               metadata: metadata,
                duration: duration,
                uuid: uuid,
                component: component
@@ -119,6 +120,7 @@ defmodule LiveToast.LiveComponent do
           component={component}
           icon={icon}
           action={action}
+          metadata={metadata}
           corner={@corner}
           title={if title, do: Utility.translate(title), else: nil}
           target={@myself}


### PR DESCRIPTION
## Summary
- add a public `metadata` option that preserves application-defined maps on toasts
- pass metadata through to custom component functions without LiveToast interpreting it
- document the custom-component extension point and add an interactive conditional-icon recipe

## Testing
- `cd demo && mix test`
- `mix format --check-formatted`