### PR TITLE
Make translation opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,22 @@ You can change where toasts are anchored by passing the `corner` setting to `toa
 
 ### Internationalization
 
-You can provide translations for the defaul error toasts by adding the following to your `config.exs`:
+LiveToast can translate its built-in connection notices. Enable this by adding the following to your `config.exs`:
 
 ```elixir
 config :live_toast,
   gettext_backend: MyApp.Gettext
+```
+
+Without this configuration, LiveToast renders its built-in connection notices in English.
+
+`send_toast/3`, `put_toast/4`, and custom connection-notification copy render the message and title you provide unchanged. Translate application-owned copy before passing it to LiveToast:
+
+```elixir
+LiveToast.send_toast(
+  :error,
+  MyApp.Gettext.dgettext("errors", "Failed to send the email")
+)
 ```
 
 You have to create a `live_toast.po` file, inside the `priv/gettext/<language>/LC_MESSAGES/` folder for each language you want to support.

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,3 @@ if Mix.env() == :dev do
         ~w(--format=iife --target=es2016 --global-name=LiveMotion --minify --outfile=../priv/static/live_toast.min.js)
       )
 end
-
-config :live_toast,
-  gettext_backend: LiveToast.Gettext

--- a/lib/live_toast/components.ex
+++ b/lib/live_toast/components.ex
@@ -169,7 +169,7 @@ defmodule LiveToast.Components do
         toast_class_fn={@toast_class_fn}
         id="client-error"
         kind={@connection_notifications.client_error.kind}
-        title={Utility.translate(@connection_notifications.client_error.title)}
+        title={@connection_notifications.client_error.title}
         duration={0}
         dismissible={false}
         data-live-toast-connection="client_error"
@@ -182,7 +182,7 @@ defmodule LiveToast.Components do
         hidden
       >
         <%= if @client_error == [] do %>
-          {Utility.translate(@connection_notifications.client_error.body)}
+          {@connection_notifications.client_error.body}
           <Utility.svg name="hero-arrow-path" class="inline-block ml-1 h-3 w-3 animate-spin" />
         <% else %>
           {render_slot(
@@ -198,7 +198,7 @@ defmodule LiveToast.Components do
         toast_class_fn={@toast_class_fn}
         id="server-error"
         kind={@connection_notifications.server_error.kind}
-        title={Utility.translate(@connection_notifications.server_error.title)}
+        title={@connection_notifications.server_error.title}
         duration={0}
         dismissible={false}
         data-live-toast-connection="server_error"
@@ -211,7 +211,7 @@ defmodule LiveToast.Components do
         hidden
       >
         <%= if @server_error == [] do %>
-          {Utility.translate(@connection_notifications.server_error.body)}
+          {@connection_notifications.server_error.body}
           <Utility.svg name="hero-arrow-path" class="inline-block ml-1 h-3 w-3 animate-spin" />
         <% else %>
           {render_slot(
@@ -285,13 +285,13 @@ defmodule LiveToast.Components do
     defaults = %{
       client_error: %{
         kind: :error,
-        title: "We can't find the internet",
-        body: "Attempting to reconnect"
+        title: Utility.translate("We can't find the internet"),
+        body: Utility.translate("Attempting to reconnect")
       },
       server_error: %{
         kind: :error,
-        title: "Something went wrong!",
-        body: "Hang in there while we get back on track"
+        title: Utility.translate("Something went wrong!"),
+        body: Utility.translate("Hang in there while we get back on track")
       }
     }
 

--- a/lib/live_toast/gettext.ex
+++ b/lib/live_toast/gettext.ex
@@ -1,4 +1,0 @@
-defmodule LiveToast.Gettext do
-  @moduledoc false
-  use Gettext.Backend, otp_app: :live_toast
-end

--- a/lib/live_toast/live_component.ex
+++ b/lib/live_toast/live_component.ex
@@ -4,7 +4,6 @@ defmodule LiveToast.LiveComponent do
   use Phoenix.LiveComponent
 
   alias LiveToast.Components
-  alias LiveToast.Utility
 
   @client_toast_option_keys ~w(duration metadata title)
 
@@ -130,10 +129,10 @@ defmodule LiveToast.LiveComponent do
           action={action}
           metadata={metadata}
           corner={@corner}
-          title={if title, do: Utility.translate(title), else: nil}
+          title={title}
           target={@myself}
         >
-          {Utility.translate(msg)}
+          {msg}
         </Components.toast>
       </div>
 

--- a/lib/live_toast/utility.ex
+++ b/lib/live_toast/utility.ex
@@ -75,8 +75,9 @@ defmodule LiveToast.Utility do
   end
 
   def translate(message) do
-    :live_toast
-    |> Application.get_env(:gettext_backend, LiveToast.Gettext)
-    |> Gettext.dgettext("live_toast", message)
+    case Application.get_env(:live_toast, :gettext_backend) do
+      nil -> message
+      backend -> Gettext.dgettext(backend, "live_toast", message)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -74,7 +74,6 @@ defmodule LiveToast.MixProject do
     lib/live_toast/components.ex
     lib/live_toast/live_component.ex
     lib/live_toast/utility.ex
-    lib/live_toast/gettext.ex
     CHANGELOG.md
     LICENSE.md
     mix.exs


### PR DESCRIPTION
Resolves: #56

high level:

Limits LiveToast translation to its four built-in connection-notice strings, and only when an application configures gettext_backend. Messages and titles supplied through send_toast/3, put_toast/4, or custom connection-notification copy now pass through unchanged, so applications own their translation context and arbitrary toast content is never sent to Gettext.

Basically, I think it was a mistake in https://github.com/srcrip/live_toast/issues/13 to add these translation capabilities to the regular put_toast functions. it really should have only ever let you easier translate those built in connection lost strings. This is technically a breaking change, so sorry but its better this way.